### PR TITLE
Update PendingEveryNDaysRepeat.php

### DIFF
--- a/src/Support/PendingRepeats/PendingEveryNDaysRepeat.php
+++ b/src/Support/PendingRepeats/PendingEveryNDaysRepeat.php
@@ -16,7 +16,8 @@ class PendingEveryNDaysRepeat extends PendingRepeat
 
     public function endsAfter(int $times): static
     {
-        $this->end_at = $this->start_at->addSeconds($times * $this->interval);
+        $this->end_at = clone $this->start_at;
+        $this->end_at->addSeconds($times * $this->interval);
 
         return $this;
     }


### PR DESCRIPTION
The endsAfter method is indirectly updating the $this->start_at value due to object reference instead of creating its own CarbonInterface object.